### PR TITLE
fix: support double values for price

### DIFF
--- a/src/models/Ticket.ts
+++ b/src/models/Ticket.ts
@@ -12,12 +12,8 @@ export const decodeTicket = (
   try {
     const decoded = atob(code);
 
-    if (!decoded.match(/.+:\d{6}:\d+:\d+/g)) {
-      onError(
-        'Unsupported ticket format!\n' +
-          'Expected Format: <UserId>:<TOTP>:<Quantity>:<Price>',
-      );
-
+    if (!decoded.match(/^.+:\d{6}:\d+:\d+(\.\d+)?$/g)) {
+      onError('Unsupported ticket format!');
       return null;
     }
 


### PR DESCRIPTION
#### Old Regex

Price gets accepted unexpectedly

![image](https://user-images.githubusercontent.com/41103290/115057889-e2383a80-9ee4-11eb-8139-004cefac17ca.png)

#### New Regex

Price gets accepted as intended

![image](https://user-images.githubusercontent.com/41103290/115058132-2e837a80-9ee5-11eb-8489-33d36134a9be.png)
